### PR TITLE
Parser: Trim whitespace from header values in accordance with RFC 9110

### DIFF
--- a/src/headers/accept.rs
+++ b/src/headers/accept.rs
@@ -204,7 +204,7 @@ impl super::TypedHeader for Accept {
             }
 
             if let Some(ref t) = media_type.type_ {
-                write!(&mut media_types, "{}", t).unwrap();
+                write!(&mut media_types, "{t}").unwrap();
             } else {
                 media_types.push('*');
             }
@@ -242,7 +242,7 @@ impl super::TypedAppendableHeader for Accept {
             }
 
             if let Some(ref t) = media_type.type_ {
-                write!(&mut media_types, "{}", t).unwrap();
+                write!(&mut media_types, "{t}").unwrap();
             } else {
                 media_types.push('*');
             }

--- a/src/headers/media_properties.rs
+++ b/src/headers/media_properties.rs
@@ -42,7 +42,7 @@ impl fmt::Display for MediaProperty {
         use fmt::Write;
 
         match self {
-            MediaProperty::RandomAccess(Some(dur)) => write!(f, "Random-Access={}", dur),
+            MediaProperty::RandomAccess(Some(dur)) => write!(f, "Random-Access={dur}"),
             MediaProperty::RandomAccess(None) => f.write_str("Random-Access"),
             MediaProperty::BeginningOnly => f.write_str("Beginning-Only"),
             MediaProperty::NoSeeking => f.write_str("No-Seeking"),
@@ -50,19 +50,19 @@ impl fmt::Display for MediaProperty {
             MediaProperty::Dynamic => f.write_str("Dynamic"),
             MediaProperty::TimeProgressing => f.write_str("Time-Progressing"),
             MediaProperty::Unlimited => f.write_str("Unlimited"),
-            MediaProperty::TimeLimited(time) => write!(f, "Time-Limited={}", time),
-            MediaProperty::TimeDuration(dur) => write!(f, "Time-Duration={}", dur),
+            MediaProperty::TimeLimited(time) => write!(f, "Time-Limited={time}"),
+            MediaProperty::TimeDuration(dur) => write!(f, "Time-Duration={dur}"),
             MediaProperty::Scales(scales) => {
                 let mut s = String::new();
                 for scale in scales {
                     if !s.is_empty() {
                         s.push_str(", ");
                     }
-                    write!(&mut s, "{}", scale).unwrap();
+                    write!(&mut s, "{scale}").unwrap();
                 }
-                write!(f, "Scales=\"{}\"", s)
+                write!(f, "Scales=\"{s}\"")
             }
-            MediaProperty::Extension(key, Some(value)) => write!(f, "{}={}", key, value),
+            MediaProperty::Extension(key, Some(value)) => write!(f, "{key}={value}"),
             MediaProperty::Extension(key, None) => f.write_str(key),
         }
     }
@@ -78,8 +78,8 @@ pub enum ScaleRange {
 impl fmt::Display for ScaleRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ScaleRange::Scale(scale) => write!(f, "{}", scale),
-            ScaleRange::Range(a, b) => write!(f, "{}:{}", a, b),
+            ScaleRange::Scale(scale) => write!(f, "{scale}"),
+            ScaleRange::Range(a, b) => write!(f, "{a}:{b}"),
         }
     }
 }

--- a/src/headers/range.rs
+++ b/src/headers/range.rs
@@ -64,9 +64,9 @@ impl fmt::Display for NptRange {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NptRange::Empty => fmt.write_str("npt"),
-            NptRange::From(f) => write!(fmt, "npt={}-", f),
-            NptRange::FromTo(f, t) => write!(fmt, "npt={}-{}", f, t),
-            NptRange::To(t) => write!(fmt, "npt=-{}", t),
+            NptRange::From(f) => write!(fmt, "npt={f}-"),
+            NptRange::FromTo(f, t) => write!(fmt, "npt={f}-{t}"),
+            NptRange::To(t) => write!(fmt, "npt=-{t}"),
         }
     }
 }
@@ -118,18 +118,16 @@ impl fmt::Display for NptTime {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NptTime::Now => fmt.write_str("now"),
-            NptTime::Seconds(seconds, None) => write!(fmt, "{}", seconds),
+            NptTime::Seconds(seconds, None) => write!(fmt, "{seconds}"),
             NptTime::Seconds(seconds, Some(nanoseconds)) => {
-                write!(fmt, "{}.{:09}", seconds, nanoseconds)
+                write!(fmt, "{seconds}.{nanoseconds:09}")
             }
             NptTime::Hms(hours, minutes, seconds, None) => {
-                write!(fmt, "{:02}:{:02}:{:02}", hours, minutes, seconds)
+                write!(fmt, "{hours:02}:{minutes:02}:{seconds:02}")
             }
-            NptTime::Hms(hours, minutes, seconds, Some(nanoseconds)) => write!(
-                fmt,
-                "{:02}:{:02}:{:02}.{:09}",
-                hours, minutes, seconds, nanoseconds
-            ),
+            NptTime::Hms(hours, minutes, seconds, Some(nanoseconds)) => {
+                write!(fmt, "{hours:02}:{minutes:02}:{seconds:02}.{nanoseconds:09}")
+            }
         }
     }
 }
@@ -207,10 +205,10 @@ pub enum SmpteRange {
 impl fmt::Display for SmpteRange {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SmpteRange::Empty(ty) => write!(fmt, "{}", ty),
-            SmpteRange::From(ty, f) => write!(fmt, "{}={}-", ty, f),
-            SmpteRange::FromTo(ty, f, t) => write!(fmt, "{}={}-{}", ty, f, t),
-            SmpteRange::To(ty, t) => write!(fmt, "{}=-{}", ty, t),
+            SmpteRange::Empty(ty) => write!(fmt, "{ty}"),
+            SmpteRange::From(ty, f) => write!(fmt, "{ty}={f}-"),
+            SmpteRange::FromTo(ty, f, t) => write!(fmt, "{ty}={f}-{t}"),
+            SmpteRange::To(ty, t) => write!(fmt, "{ty}=-{t}"),
         }
     }
 }
@@ -407,9 +405,9 @@ impl fmt::Display for UtcRange {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             UtcRange::Empty => fmt.write_str("clock"),
-            UtcRange::From(f) => write!(fmt, "clock={}-", f),
-            UtcRange::FromTo(f, t) => write!(fmt, "clock={}-{}", f, t),
-            UtcRange::To(t) => write!(fmt, "clock=-{}", t),
+            UtcRange::From(f) => write!(fmt, "clock={f}-"),
+            UtcRange::FromTo(f, t) => write!(fmt, "clock={f}-{t}"),
+            UtcRange::To(t) => write!(fmt, "clock=-{t}"),
         }
     }
 }
@@ -573,7 +571,7 @@ mod tests {
                 .unwrap_or_else(|_| panic!("couldn't parse {}", header))
                 .unwrap();
 
-            assert_eq!(range, *expected, "{}", header);
+            assert_eq!(range, *expected, "{header}");
 
             let request2 = crate::Request::builder(crate::Method::Play, crate::Version::V2_0)
                 .typed_header(&range)
@@ -581,7 +579,7 @@ mod tests {
 
             let range = request2.header(&crate::headers::RANGE).unwrap();
 
-            assert_eq!(range, serialized.unwrap_or(header), "{}", header);
+            assert_eq!(range, serialized.unwrap_or(header), "{header}");
         }
     }
 }

--- a/src/headers/rtp_info.rs
+++ b/src/headers/rtp_info.rs
@@ -323,11 +323,11 @@ impl super::TypedHeader for RtpInfos {
                     write!(&mut infos, "url={}", info.uri).unwrap();
 
                     if let Some(seq) = info.seq {
-                        write!(&mut infos, ";seq={}", seq).unwrap();
+                        write!(&mut infos, ";seq={seq}").unwrap();
                     }
 
                     if let Some(rtptime) = info.rtptime {
-                        write!(&mut infos, ";rtptime={}", rtptime).unwrap();
+                        write!(&mut infos, ";rtptime={rtptime}").unwrap();
                     }
                 }
             }
@@ -352,7 +352,7 @@ impl super::TypedHeader for RtpInfos {
                         let mut need_semi = false;
 
                         if let Some(seq) = ssrc.seq {
-                            write!(&mut infos, "seq={}", seq).unwrap();
+                            write!(&mut infos, "seq={seq}").unwrap();
                             need_semi = true;
                         }
 
@@ -360,7 +360,7 @@ impl super::TypedHeader for RtpInfos {
                             if need_semi {
                                 infos.push(';');
                             }
-                            write!(&mut infos, "rtptime={}", rtptime).unwrap();
+                            write!(&mut infos, "rtptime={rtptime}").unwrap();
                             need_semi = true;
                         }
 
@@ -369,9 +369,9 @@ impl super::TypedHeader for RtpInfos {
                                 infos.push(';');
                             }
                             if let Some(value) = value {
-                                write!(&mut infos, "{}={}", name, value).unwrap();
+                                write!(&mut infos, "{name}={value}").unwrap();
                             } else {
-                                write!(&mut infos, "{}", name).unwrap();
+                                write!(&mut infos, "{name}").unwrap();
                             }
                             need_semi = true;
                         }

--- a/src/headers/session.rs
+++ b/src/headers/session.rs
@@ -161,7 +161,7 @@ mod tests {
             let from_headers_result =
                 Session::from_headers(test_headers).expect("strict_headers should not error");
 
-            assert_eq!(from_headers_result, expected, "{}", header);
+            assert_eq!(from_headers_result, expected, "{header}");
         }
 
         for (header, expected) in loose_headers {
@@ -170,7 +170,7 @@ mod tests {
             let from_headers_result =
                 Session::from_headers(test_headers).expect("loose_errors should not error");
 
-            assert_eq!(from_headers_result, expected, "{}", header);
+            assert_eq!(from_headers_result, expected, "{header}");
         }
 
         for header in bad_headers {
@@ -187,7 +187,7 @@ mod tests {
             let from_headers_result =
                 Session::from_headers(test_headers).expect("not_session_headers should not error");
 
-            assert_eq!(from_headers_result, None, "{}:{}", header, value);
+            assert_eq!(from_headers_result, None, "{header}:{value}");
         }
     }
 }

--- a/src/headers/transport.rs
+++ b/src/headers/transport.rs
@@ -609,15 +609,15 @@ impl super::TypedHeader for Transports {
 
                     if let Some((channel_start, channel_end)) = &rtp.params.interleaved {
                         transports.push(';');
-                        write!(&mut transports, "interleaved={}", channel_start).unwrap();
+                        write!(&mut transports, "interleaved={channel_start}").unwrap();
                         if let Some(channel_end) = channel_end {
-                            write!(&mut transports, "-{}", channel_end).unwrap();
+                            write!(&mut transports, "-{channel_end}").unwrap();
                         }
                     }
 
                     if let Some(ttl) = rtp.params.ttl {
                         transports.push(';');
-                        write!(&mut transports, "ttl={}", ttl).unwrap();
+                        write!(&mut transports, "ttl={ttl}").unwrap();
                     }
 
                     if !rtp.params.ssrc.is_empty() {
@@ -632,7 +632,7 @@ impl super::TypedHeader for Transports {
                                 transports.push('/');
                             }
 
-                            write!(&mut transports, "{:08X}", ssrc).unwrap();
+                            write!(&mut transports, "{ssrc:08X}").unwrap();
                         }
                     }
 
@@ -648,7 +648,7 @@ impl super::TypedHeader for Transports {
                                 transports.push('/');
                             }
 
-                            write!(&mut transports, "\"{}\"", addr).unwrap()
+                            write!(&mut transports, "\"{addr}\"").unwrap()
                         }
                     }
 
@@ -664,7 +664,7 @@ impl super::TypedHeader for Transports {
                                 transports.push('/');
                             }
 
-                            write!(&mut transports, "\"{}\"", addr).unwrap()
+                            write!(&mut transports, "\"{addr}\"").unwrap()
                         }
                     }
 
@@ -675,36 +675,36 @@ impl super::TypedHeader for Transports {
 
                     if let Some((port_start, port_end)) = rtp.params.port {
                         transports.push(';');
-                        write!(&mut transports, "port={}", port_start).unwrap();
+                        write!(&mut transports, "port={port_start}").unwrap();
                         if let Some(port_end) = port_end {
-                            write!(&mut transports, "-{}", port_end).unwrap();
+                            write!(&mut transports, "-{port_end}").unwrap();
                         }
                     }
 
                     if let Some((port_start, port_end)) = rtp.params.client_port {
                         transports.push(';');
-                        write!(&mut transports, "client_port={}", port_start).unwrap();
+                        write!(&mut transports, "client_port={port_start}").unwrap();
                         if let Some(port_end) = port_end {
-                            write!(&mut transports, "-{}", port_end).unwrap();
+                            write!(&mut transports, "-{port_end}").unwrap();
                         }
                     }
 
                     if let Some((port_start, port_end)) = rtp.params.server_port {
                         transports.push(';');
-                        write!(&mut transports, "server_port={}", port_start).unwrap();
+                        write!(&mut transports, "server_port={port_start}").unwrap();
                         if let Some(port_end) = port_end {
-                            write!(&mut transports, "-{}", port_end).unwrap();
+                            write!(&mut transports, "-{port_end}").unwrap();
                         }
                     }
 
                     if let Some(ref destination) = rtp.params.destination {
                         transports.push(';');
-                        write!(&mut transports, "destination={}", destination).unwrap();
+                        write!(&mut transports, "destination={destination}").unwrap();
                     }
 
                     if let Some(ref source) = rtp.params.source {
                         transports.push(';');
-                        write!(&mut transports, "source={}", source).unwrap();
+                        write!(&mut transports, "source={source}").unwrap();
                     }
 
                     if !rtp.params.mode.is_empty() {
@@ -734,7 +734,7 @@ impl super::TypedHeader for Transports {
                         transports.push(';');
 
                         if let Some(value) = value {
-                            write!(&mut transports, "{}={}", name, value).unwrap();
+                            write!(&mut transports, "{name}={value}").unwrap();
                         } else {
                             transports.push_str(name);
                         }
@@ -747,7 +747,7 @@ impl super::TypedHeader for Transports {
                         transports.push(';');
 
                         if let Some(value) = value {
-                            write!(&mut transports, "{}={}", name, value).unwrap();
+                            write!(&mut transports, "{name}={value}").unwrap();
                         } else {
                             transports.push_str(name);
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl fmt::Display for StatusCode {
             StatusCode::RTSPVersionNotSupported => write!(fmt, "RTSP Version Not Supported"),
             StatusCode::OptionNotSupported => write!(fmt, "Option Not Supported"),
             StatusCode::ProxyUnavailable => write!(fmt, "Proxy Unavailable"),
-            StatusCode::Extension(v) => write!(fmt, "Extension {}", v),
+            StatusCode::Extension(v) => write!(fmt, "Extension {v}"),
         }
     }
 }
@@ -522,7 +522,7 @@ impl std::error::Error for WriteError {
 impl std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            WriteError::IoError(ref error) => write!(f, "Write IO error: {}", error),
+            WriteError::IoError(ref error) => write!(f, "Write IO error: {error}"),
         }
     }
 }


### PR DESCRIPTION
This PR trims leading and trailing whitespace on parsed header values. I would have opted to use [trim_ascii](https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.trim_ascii), however that function is not stabilized for &[u8], so instead I copied their implementation here with comment. 

I also considered modifying the parser combinator, but I felt that this approach was much clearer in respect to how the header value was being transformed. 